### PR TITLE
Install all iPython dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We recommend running the examples with Ipython Notebook:
 git clone git@github.com:o19s/relevant-search-book.git
 cd relevant-search-book
 pip install requests
-pip install ipython
+pip install "ipython[all]"
 cd ipython/
 export TMDB_API_KEY=<...>
 ipyton notebook


### PR DESCRIPTION
I created a new virtual environment for the book's source code and only doing `pip install ipython` caused and error, when trying to open iPython's notebook, regarding some missing dependencies. I'd suggest installing all dependencies right away.
